### PR TITLE
Track campaign subject and only log opens on view

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503

--- a/email_marketing/tracking/server.py
+++ b/email_marketing/tracking/server.py
@@ -1,4 +1,3 @@
-
 """Web server for tracking email engagement events.
 
 This module exposes a typed API using FastAPI.  It records events such as
@@ -17,12 +16,12 @@ import datetime as dt
 import os
 import sqlite3
 import uuid
+from pathlib import Path
 from typing import Optional
 
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import PlainTextResponse, RedirectResponse, FileResponse
+from fastapi.responses import FileResponse, PlainTextResponse, RedirectResponse
 from pydantic import BaseModel, EmailStr
-from pathlib import Path
 
 
 def _get_db_path() -> str:
@@ -39,9 +38,7 @@ def _ensure_campaign_column() -> None:
     """
     db = _get_db_path()
     with sqlite3.connect(db) as conn:
-        cols = [row[1] for row in conn.execute(
-            "PRAGMA table_info(events)").fetchall()
-            ]
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(events)").fetchall()]
         if "campaign" not in cols:
             conn.execute("ALTER TABLE events ADD COLUMN campaign TEXT")
             conn.commit()
@@ -64,23 +61,11 @@ def _init_db() -> None:
         )
 
 
-def _record_event(msg_id: str,
-                  event_type: str,
-                  client_ip: Optional[str],
-                  campaign: Optional[str]
-                  ) -> None:
+def _record_event(
+    msg_id: str, event_type: str, client_ip: Optional[str], campaign: Optional[str]
+) -> None:
     """Insert a new event into the SQLite database."""
     with sqlite3.connect(_get_db_path()) as conn:
-        if event_type == "open":
-            cur = conn.execute("SELECT COUNT(*) FROM events WHERE msg_id = ?",
-                               (msg_id,))
-            count = cur.fetchone()[0]
-            if count == 0:
-                event_type_to_store = "send"
-            else:
-                event_type_to_store = "open"
-        else:
-            event_type_to_store = event_type
         conn.execute(
             """
             INSERT INTO events
@@ -89,11 +74,11 @@ def _record_event(msg_id: str,
             """,
             (
                 msg_id,
-                event_type_to_store,
+                event_type,
                 client_ip,
                 dt.datetime.utcnow().isoformat(),
                 campaign,
-            )
+            ),
         )
         conn.commit()
 
@@ -101,6 +86,7 @@ def _record_event(msg_id: str,
 app = FastAPI(title="Mailmkt Tracking API")
 
 _init_db()
+_ensure_campaign_column()
 
 
 class ClickEvent(BaseModel):
@@ -116,18 +102,16 @@ class SubscribeRequest(BaseModel):
     email: EmailStr
 
 
-@app.get("/pixel", response_class=Response,
-         summary="Tracking pixel")
+@app.get("/pixel", response_class=Response, summary="Tracking pixel")
 async def pixel(
-        request: Request,
-        msg_id: str,
-        campaign: Optional[str] = None,
-        ts: Optional[str] = None  # parámetro anti-cache
-        ) -> Response:
+    request: Request,
+    msg_id: str,
+    campaign: Optional[str] = None,
+    ts: Optional[str] = None,  # parámetro anti-cache
+) -> Response:
     """Return a 1×1 GIF, record an 'open', y evitar caching."""
-    # client_ip = request.client.host if request.client else None
-    # print(f"[DEBUG] PIXEL HIT msg_id={msg_id} from {client_ip}")
-    # _record_event(msg_id, "open", client_ip)
+    client_ip = request.client.host if request.client else None
+    _record_event(msg_id, "open", client_ip, campaign)
 
     # Decode the 1×1 transparent GIF
     gif_b64 = "R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
@@ -140,51 +124,50 @@ async def pixel(
         "Expires": "0",
     }
 
-    return Response(content=pixel_bytes, media_type="image/gif",
-                    headers=headers)
+    return Response(content=pixel_bytes, media_type="image/gif", headers=headers)
 
 
 @app.head("/pixel", include_in_schema=False)
 async def pixel_head(request: Request, msg_id: str) -> Response:
     headers = {
-         "Cache-Control": "no-cache, no-store, must-revalidate",
-         "Pragma":        "no-cache",
-         "Expires":       "0",
-         "Content-Type":  "image/gif",
-     }
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "Content-Type": "image/gif",
+    }
     return Response(status_code=200, headers=headers)
 
 
-@app.get("/click", response_class=RedirectResponse,
-         summary="Record click via GET and redirect")
-async def click_get(request: Request,
-                    msg_id: str,
-                    url: str
-                    ) -> RedirectResponse:
+@app.get("/click", response_class=RedirectResponse, summary="Record click via GET and redirect")
+async def click_get(
+    request: Request,
+    msg_id: str,
+    url: str,
+    campaign: Optional[str] = None,
+) -> RedirectResponse:
     """Record a click event via GET and redirect to the target URL."""
     client_ip = request.client.host if request.client else None
-    # print(f"[DEBUG] CLICK HIT msg_id={msg_id}, redirecting to {url}")
-    _record_event(msg_id, "click", client_ip, None)
+    _record_event(msg_id, "click", client_ip, campaign)
     return RedirectResponse(url)
 
 
-@app.get("/unsubscribe", response_class=PlainTextResponse,
-         summary="Handle unsubscribe via GET")
-async def unsubscribe_get(request: Request, msg_id: str) -> PlainTextResponse:
+@app.get("/unsubscribe", response_class=PlainTextResponse, summary="Handle unsubscribe via GET")
+async def unsubscribe_get(
+    request: Request, msg_id: str, campaign: Optional[str] = None
+) -> PlainTextResponse:
     """Record an unsubscribe event via GET and confirm."""
     client_ip = request.client.host if request.client else None
-    # print(f"[DEBUG] UNSUBSCRIBE HIT msg_id={msg_id}")
-    _record_event(msg_id, "unsubscribe", client_ip, None)
+    _record_event(msg_id, "unsubscribe", client_ip, campaign)
     return PlainTextResponse("You have been unsubscribed")
 
 
-@app.get("/complaint", response_class=PlainTextResponse,
-         summary="Handle complaint via GET")
-async def complaint_get(request: Request, msg_id: str) -> PlainTextResponse:
+@app.get("/complaint", response_class=PlainTextResponse, summary="Handle complaint via GET")
+async def complaint_get(
+    request: Request, msg_id: str, campaign: Optional[str] = None
+) -> PlainTextResponse:
     """Record a spam complaint event via GET and confirm."""
     client_ip = request.client.host if request.client else None
-    # print(f"[DEBUG] COMPLAINT HIT msg_id={msg_id}")
-    _record_event(msg_id, "complaint", client_ip, None)
+    _record_event(msg_id, "complaint", client_ip, campaign)
     return PlainTextResponse("Thank you, your complaint has been recorded")
 
 
@@ -193,9 +176,9 @@ async def complaint_get(request: Request, msg_id: str) -> PlainTextResponse:
     summary="Serve corporate logo and record open",
     response_class=FileResponse,
 )
-async def logo(request: Request,
-               msg_id: str,
-               ts: Optional[str] = None) -> FileResponse:
+async def logo(
+    request: Request, msg_id: str, ts: Optional[str] = None, campaign: Optional[str] = None
+) -> FileResponse:
     """
     Serve the corporate logo PNG and record an 'open' event.
     Query params:
@@ -203,23 +186,20 @@ async def logo(request: Request,
     - ts: timestamp to bust proxy cache
     """
     client_ip = request.client.host if request.client else None
-    print(f"[DEBUG] LOGO HIT msg_id={msg_id} from {client_ip}")
-    # Location of the static logo file
+    _record_event(msg_id, "open", client_ip, campaign)
+
     logo_path = Path(__file__).resolve().parent / "static" / "logo.png"
     headers = {
         "Cache-Control": "no-cache, no-store, must-revalidate",
         "Pragma": "no-cache",
         "Expires": "0",
     }
-    return FileResponse(path=logo_path, media_type="image/png",
-                        headers=headers)
+    return FileResponse(path=logo_path, media_type="image/png", headers=headers)
 
 
 # HEAD handler para el logo, para que Gmail proxy valide correctamente
 @app.head("/logo", include_in_schema=False)
-async def logo_head(request: Request,
-                    msg_id: str,
-                    ts: Optional[str] = None) -> Response:
+async def logo_head(request: Request, msg_id: str, ts: Optional[str] = None) -> Response:
     """
     Respond to HEAD so proxies (Gmail, Outlook) puedan validar la imagen.
     También grabamos el 'open' aquí.
@@ -231,15 +211,14 @@ async def logo_head(request: Request,
     # Solo devolvemos cabeceras, sin cuerpo, con Content-Type + anti-cache
     headers = {
         "Cache-Control": "no-cache, no-store, must-revalidate",
-        "Pragma":        "no-cache",
-        "Expires":       "0",
-        "Content-Type":  "image/png",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "Content-Type": "image/png",
     }
     return Response(status_code=200, headers=headers)
 
 
-@app.post("/subscribe", response_class=PlainTextResponse,
-          summary="Request double opt-in")
+@app.post("/subscribe", response_class=PlainTextResponse, summary="Request double opt-in")
 async def subscribe(req: SubscribeRequest) -> str:
     """Initiate a double opt‑in process.
 
@@ -250,8 +229,7 @@ async def subscribe(req: SubscribeRequest) -> str:
     return token
 
 
-@app.get("/confirm/{token}", response_class=PlainTextResponse,
-         summary="Confirm subscription")
+@app.get("/confirm/{token}", response_class=PlainTextResponse, summary="Confirm subscription")
 async def confirm(token: str) -> str:
     """Confirm a subscription given a token generated by :func:`subscribe`."""
     return f"subscription confirmed: {token}"
@@ -269,24 +247,27 @@ def create_app() -> FastAPI:
 
 # --- Click HEAD handler ---
 @app.head("/click", include_in_schema=False)
-async def click_head(request: Request, msg_id: str, url: str) -> Response:
+async def click_head(
+    request: Request, msg_id: str, url: str, campaign: Optional[str] = None
+) -> Response:
     client_ip = request.client.host if request.client else None
-    _record_event(msg_id, "click", client_ip, None)
-    # Devolvemos sólo la cabecera de redirección (301/307) sin cuerpo
+    _record_event(msg_id, "click", client_ip, campaign)
     return Response(status_code=307, headers={"Location": url})
 
 
 # --- Unsubscribe HEAD handler ---
 @app.head("/unsubscribe", include_in_schema=False)
-async def unsubscribe_head(request: Request, msg_id: str) -> Response:
+async def unsubscribe_head(
+    request: Request, msg_id: str, campaign: Optional[str] = None
+) -> Response:
     client_ip = request.client.host if request.client else None
-    _record_event(msg_id, "unsubscribe", client_ip, None)
+    _record_event(msg_id, "unsubscribe", client_ip, campaign)
     return Response(status_code=200)
 
 
 # --- Complaint HEAD handler ---
 @app.head("/complaint", include_in_schema=False)
-async def complaint_head(request: Request, msg_id: str) -> Response:
+async def complaint_head(request: Request, msg_id: str, campaign: Optional[str] = None) -> Response:
     client_ip = request.client.host if request.client else None
-    _record_event(msg_id, "complaint", client_ip, None)
+    _record_event(msg_id, "complaint", client_ip, campaign)
     return Response(status_code=200)


### PR DESCRIPTION
## Summary
- log open events only when tracking pixel or logo is requested
- propagate email subject as campaign across tracking links and database records
- expose campaign data in stats view and configure flake8

## Testing
- `flake8 email_marketing/tracking/server.py email_marketing/dashboard/email_editor.py email_marketing/dashboard/stats_view.py`
- `mypy email_marketing` *(fails: Argument 1 to "IMAP4_SSL" has incompatible type "str | None"; expected "str"; Library stubs not installed for "requests")*
- `pytest --cov=email_marketing --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_688e49c9b27c8323a32e5b7283799fd9